### PR TITLE
feat: implement new variable --no-attr

### DIFF
--- a/Main/Program.cs
+++ b/Main/Program.cs
@@ -5,15 +5,21 @@ class Program
     static void Main(string[] args)
     {
 #if DEBUG
+        // True if needs to compare attributes between start/end block; False if no needs.
+        bool noAttribute = false;
+        if (args.Length != 0 && args[0] == "--no-attr") {
+            noAttribute = true;
+        }
         // You can use here to test, feel free to modify/add the test cases here.
         // You can also use other ways to test if you want.
 
-        List<(string testCase, bool expectedResult)> testCases = new()
+        List<(string testCase, bool expectedResult, bool expectedResult_noAttr)> testCases = new()
         {
-            ("<Design><Code>hello world</Code></Design>",  true),//normal case
-            ("<Design><Code>hello world</Code></Design><People>", false),//no closing tag for "People" 
-            ("<People><Design><Code>hello world</People></Code></Design>", false),// "/Code" should come before "/People" 
-            ("<People age=”1”>hello world</People>", false),//there is no closing tag for "People age=”1”" and no opening tag for "/People"
+            ("<Design><Code>hello world</Code></Design>",  true, true),//normal case
+            ("<Design><Code>hello world</Code></Design><People>", false, false),//no closing tag for "People" 
+            ("<People><Design><Code>hello world</People></Code></Design>", false, false),// "/Code" should come before "/People" 
+            ("<People age=”1”>hello world</People>", false, true),//there is no closing tag for "People age=”1”" and no opening tag for "/People"
+            (@"<People age=""1"">hello world</People age=""1"">", true, true),
             (@"<?xml version=""1.0"" encoding=""UTF-8""?>
                 <books>
                     <book id=""1"">
@@ -26,17 +32,18 @@ class Program
                         <author>Hsiao David</author>
                         <price>299.9</price>
                     </book>
-                </books>", false),// My test case
+                </books>", false, true),// My test case
             
         };
         int failedCount = 0;
-        foreach ((string input, bool expected) in testCases)
+        foreach ((string input, bool expected, bool expected_noAttr) in testCases)
         {
-            bool result = SimpleXmlValidator.DetermineXml(input);
+            // Set noAttribute to check whether should compare attributes
+            bool result = SimpleXmlValidator.DetermineXml(input, noAttribute);
             string resultStr = result ? "Valid" : "Invalid";
 
             string mark;
-            if (result == expected)
+            if ((result == expected && !noAttribute) || (result == expected_noAttr && noAttribute))
             {
                 mark = "OK ";
             }

--- a/SimpleXMLValidatorLibrary/SimpleXmlValidator.cs
+++ b/SimpleXMLValidatorLibrary/SimpleXmlValidator.cs
@@ -81,24 +81,26 @@
 
     public class SimpleXmlValidator
     {
-        public static bool BlockIsMatch (XmlBlock openBlock, XmlBlock closeBlock) {
+        public static bool BlockIsMatch (XmlBlock openBlock, XmlBlock closeBlock, bool noAttribute) {
             // Check if tag name is matchs.
             if (openBlock.TagName != closeBlock.TagName) {
                 return false;
             }
             // Check if attributes are matched.
-            if (openBlock.Attributes.Count != closeBlock.Attributes.Count) {
-                return false;
-            }
-            foreach(var kvp in closeBlock.Attributes) {
-                if (!openBlock.Attributes.TryGetValue(kvp.Key, out var value) || !value.Equals(kvp.Value)) {
+            if (!noAttribute) {
+                if (openBlock.Attributes.Count != closeBlock.Attributes.Count) {
                     return false;
+                }
+                foreach(var kvp in closeBlock.Attributes) {
+                    if (!openBlock.Attributes.TryGetValue(kvp.Key, out var value) || !value.Equals(kvp.Value)) {
+                        return false;
+                    }
                 }
             }
             return true;
         }
 
-		public static bool XmlParser(string xml)
+		public static bool XmlParser(string xml, bool noAttribute)
         {
             // Current string, whether block elements or content.
             string currentTagString = string.Empty;
@@ -107,9 +109,6 @@
             // Stack of Xml blocks.
             Stack<XmlBlock> blockStack = new Stack<XmlBlock>();
 
-            // Test
-            // Console.WriteLine();
-            // Console.WriteLine(xml);
             // Read XML string by character
             foreach (char currentChar in xml)
             {
@@ -131,7 +130,7 @@
                         XmlBlock openBlock = blockStack.Pop();
 
                         // Invalid if the open and close block is unmatched.
-                        if (!BlockIsMatch(openBlock, currentBlock)) {
+                        if (!BlockIsMatch(openBlock, currentBlock, noAttribute)) {
                             return false;
                         }
 
@@ -169,9 +168,9 @@
             return true;
         }
         //Please implement this method
-        public static bool DetermineXml(string xml)
+        public static bool DetermineXml(string xml, bool noAttribute)
         {
-            bool isValid = XmlParser(xml);
+            bool isValid = XmlParser(xml, noAttribute);
 
             return isValid;
         }


### PR DESCRIPTION
### Summary
Option to compare open/close block with attributes or not using `--no-attr` argument.

### Changes
- Detemine whether needs to compare attributes with `--no-attr` argument.
- Add `expectedResult_noAttr` element for `testCase` list.
- Skip attribute comparing in function `BlockIsMatch` of class `SimpleXmlValidator` if boolean `noAttribute` is `true`.

### Screenshot
![image](https://github.com/user-attachments/assets/814792df-aaeb-4112-bae2-5a767dbb79a9)

### Related PR
Complete the future work in #7.

### Todo
- Validation
  - illegal character detection (Optional).
  - check if close block remains (Optional).