### PR TITLE
hotfix: fix end tag parsing problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 README.md
+*/obj/
+*/bin/

--- a/Main/Program.cs
+++ b/Main/Program.cs
@@ -21,6 +21,8 @@ class Program
         List<(string testCase, bool expectedResult, bool expectedResult_noAttr)> testCases = new()
         {
             ("<Design><Code>hello world</Code></Design>",  true, true),// correct case
+            ("<Design><Code>hello world<//Code></Design>",  false, false),// correct case
+            ("<Design><Code>hello world</Code ></Design >",  true, true),// correct case
             ("<Design><Code>hello world</Code></Design><People>", false, false),// no closing tag for "People"      
             ("<Design><Code>hello world</Code></Design></People>", false, false),// no opening tag for "People"
             ("<People><Design><Code>hello world</People></Code></Design>", false, false),// "/Code" should come before "/People" 

--- a/README.md
+++ b/README.md
@@ -30,18 +30,6 @@ Implement an XMLparser capable of parsing XML string.
 
 ### Todo
 
-### Summary
-
-Implement an XMLparser capable of parsing XML string.
-
-### Changes
-
-- Implement `XmlParser` in `SimpleXmlValidator` for parsing xml blocks.
-- Identifying start tags and end tags within the blocks.
-- Handling and distinguishing the XML header from tag.
-
-### Todo
-
 - Create an XML block class to manage tags, attributes, and content.
 
 ## Feature #3: Implement XML block

--- a/SimpleXMLValidatorLibrary/SimpleXmlValidator.cs
+++ b/SimpleXMLValidatorLibrary/SimpleXmlValidator.cs
@@ -36,7 +36,7 @@
             if (tagName == "xml") {
                 blockType = XmlBlockType.Xml;
             } else if (tagName.StartsWith("/")) {
-                tagName = tagName.Trim('/');
+                tagName = tagName.Substring(1, tagName.Length - 1);
                 blockType = XmlBlockType.Close;
             } else {
                 blockType = XmlBlockType.Open;


### PR DESCRIPTION
### Summary
Fix the end tag parsing problem, when multiple '/' appear, should not trim all the characters.

### Changes
- Add test case with multiple '/'.
- parse end tag name with `substring` instead of `trim`.
- update some documents